### PR TITLE
Correcciones en punto de venta y gestión de productos

### DIFF
--- a/Guardian/src/app/admin/product-management/product-management.component.html
+++ b/Guardian/src/app/admin/product-management/product-management.component.html
@@ -137,15 +137,14 @@
                   <!-- Campo de entrada para nuevo producto -->
                   <input *ngIf="selectedProduct == null" id="unitsInStock" #unitsInStockInput
                     (click)="unitsInStockInput.select()" type="number" class="form-control"
-                    formControlName="unitsInStock"
-                    [step]="productForm.get('measure')?.value === 'measure.unidad' ? 1 : 0.01"
-                    [min]="productForm.get('measure')?.value === 'measure.unidad' ? 1 : 0.01">
+                    formControlName="unitsInStock" [step]="productForm.get('measure')?.value === measure.Ud ? 1 : 0.01"
+                    [min]="productForm.get('measure')?.value === measure.Ud ? 1 : 0.01">
 
                   <!-- Campo para agregar inventario a producto existente -->
                   <input *ngIf="showAddInventarioBox" class="bg-warning" #addToInventoryValInput
                     (click)="addToInventoryValInput.select()" formControlName="addToInventoryVal" type="number"
-                    [step]="productForm.get('measure')?.value === 'measure.unidad' ? 1 : 0.01"
-                    [min]="productForm.get('measure')?.value === 'measure.unidad' ? 1 : 0.01" max="1000000">
+                    [step]="productForm.get('measure')?.value === measure.Ud ? 1 : 0.01"
+                    [min]="productForm.get('measure')?.value === measure.Ud ? 1 : 0.01" max="1000000">
 
                   <button *ngIf="this.selectedProduct" class="ms-2 btn btn-primary"
                     [ngClass]="{'btn-success': showAddInventarioBox}"

--- a/Guardian/src/app/admin/product-management/product-management.component.ts
+++ b/Guardian/src/app/admin/product-management/product-management.component.ts
@@ -36,7 +36,7 @@ export class ProductManagementComponent implements OnInit {
   cStatus = CompanyStatus;
   selectedCategoryId: number = 0;
   moreItems: boolean | undefined;
-
+  previousMeasure: MeasureType = MeasureType.Ud;
 
   constructor(
     private fb: FormBuilder,
@@ -85,8 +85,23 @@ export class ProductManagementComponent implements OnInit {
     this.searchProductsInternal('-1');
     this.navigationService.checkScreenSize();
     this.navigationService.showFreeLicenseMsg(this.userState.companyStatusId ?? 0);
-
     this.getCategories();
+
+    this.productForm.get('measure')?.valueChanges.subscribe((newMeasure) => {
+      const units = this.productForm.get('unitsInStock')?.value;
+
+      if (this.previousMeasure !== newMeasure) {
+        // Si la medida cambia
+        if (newMeasure === MeasureType.Ud && units % 1 !== 0) {
+          this.navigationService.showUIMessage(
+            this.translate.instant('product.adverticed_unit'),
+            AlertLevel.Warning
+          );
+        }
+        this.previousMeasure = newMeasure;
+      }
+    });
+
   }
 
   openCaptureInventory() {
@@ -234,6 +249,9 @@ export class ProductManagementComponent implements OnInit {
       .subscribe(product => {
         this.selectedProduct = product;
         this.productForm.patchValue(product);
+
+        this.previousMeasure = product.measure;
+
         if (this.userState.companyStatusId == this.cStatus.Free) {
           this.productForm.get('unitPrice1')?.disable();
           this.productForm.get('unitPrice2')?.disable();

--- a/Guardian/src/app/pdv-lista-venta/lista-venta.component.html
+++ b/Guardian/src/app/pdv-lista-venta/lista-venta.component.html
@@ -31,14 +31,17 @@
 
         </td>
         <!-- Celda para mostrar o editar la cantidad -->
-        <td (mouseenter)="producto.editing = true" (mouseleave)="producto.editing = false">
+        <td>
+          <!-- Campo intercambiable para la edición -->
+          <span *ngIf="!producto.editing; else editInput" (click)="enableEditing(producto)" style="max-width: 10px;">
+            {{ producto.count }}
+          </span>
 
-          <!-- Mostrar input si el cursor está encima -->
-          <ng-container *ngIf="producto.editing; else mostrarCantidad">
+          <ng-template #editInput>
             <input type="number" min="1" [(ngModel)]="producto.count" (change)="onCountChange(producto)"
-              class="form-control-sm text-center" style="width: 70px;"
-              [step]="producto.measure === measure.Ud ? '1' : '0.01'" />
-          </ng-container>
+              (keydown.enter)="disableEditing(producto, $event)" class="form-control-sm text-center"
+              style="width: 70px;" [step]="producto.measure === measure.Ud ? '1' : '0.01'" />
+          </ng-template>
 
           <!-- Mostrar solo el número si no se está editando -->
           <ng-template #mostrarCantidad>

--- a/Guardian/src/app/pdv-lista-venta/lista-venta.component.ts
+++ b/Guardian/src/app/pdv-lista-venta/lista-venta.component.ts
@@ -308,19 +308,22 @@ export class ListaVentaComponent implements OnInit, OnDestroy {
 
   disableEditing(item: Producto, event: any) {
     const newValue = this.inputNumber?.nativeElement.value;
-    if (newValue > 0 && newValue != this.tempProductCounter) {
+    if (newValue > 0 && newValue != this.tempProductCounter) 
+    {
       item.count = newValue; // Acepta el nuevo valor si es mayor que cero
       item.editing = false;  // Desactiva el modo de edición
-
+      
       this.ventaService.updateNumOfProductos(item.productId, newValue);
-    }
-    else {
-      if (newValue <= 0) {
-        this.navigationService.showUIMessage(this.translate.instant('list_sale.amount_must_be_positive'), AlertLevel.Warning);
-        item.count = this.tempProductCounter ?? 0;
-      }
+    } 
+    else 
+    {
+      if(newValue <= 0)
+      {
+        this.navigationService.showUIMessage(this.translate.instant('list_sale.invalid_quantity_unit'), AlertLevel.Warning);
+        item.count = this.tempProductCounter?? 0;
+      } 
       item.editing = false;
-
+      
     }
     event.preventDefault();
   }

--- a/Guardian/src/assets/i18n/es.json
+++ b/Guardian/src/assets/i18n/es.json
@@ -24,7 +24,9 @@
     "not_found": "El producto no fue encontrado.",
     "no_products_category": "No hay productos en la categoría seleccionada.",
     "error_application": "Error al procesar la solicitud. Servidor no disponible.",
-    "information_missing": "Proporciona toda la información requerida"
+    "information_missing": "Proporciona toda la información requerida",
+    "adverticed_unit":"La unidad fue cambiada a 'unidad'. El stock se redondeará automáticamente al valor entero más bajo."
+
   },
   "list_sale": {
     "invalid_quantity_unit": "El producto está configurado como 'Unidad' y no puede tener cantidad decimal.",

--- a/UsaloYa.Dto/Enums/Enums.cs
+++ b/UsaloYa.Dto/Enums/Enums.cs
@@ -42,7 +42,7 @@
     }
     public enum MeasureType
     {
-        Unidad = 1,
+        Ud = 1,
         Kg = 2
     }
 

--- a/UsaloYa.Services/ProductService.cs
+++ b/UsaloYa.Services/ProductService.cs
@@ -266,7 +266,17 @@ namespace UsaloYa.Services
             var user = await HeaderValidatorService.ValidateRequestor(requestorId, Role.Admin, _dBContext);
             if (user.UserId <= 0) return null;
 
+
             if (productDto.Equals(default(ProductDto)) || companyId <= 0) return null;
+
+            // Suponiendo que Measure es un enum o int que indica el tipo de medida
+            if (productDto.Measure == (int)MeasureType.Ud)
+            {
+                // Truncar UnitsInStock a entero (sin decimales)
+                productDto.UnitsInStock = Math.Floor(productDto.UnitsInStock);
+            }
+
+
 
             var existingProduct = await _dBContext.Products
                 .FirstOrDefaultAsync(p => p.ProductId == productDto.ProductId && p.CompanyId == companyId);
@@ -297,9 +307,7 @@ namespace UsaloYa.Services
                     UnitPrice2 = productDto.UnitPrice2,
                     UnitPrice3 = productDto.UnitPrice3,
                     UnitsInStock = productDto.UnitsInStock,
-
                     Measure = productDto.Measure,
-
                     Discontinued = productDto.Discontinued,
                     DateModified = Utils.GetMxDateTime(),
                     Sku = string.IsNullOrEmpty(productDto.SKU) ? null : productDto.SKU,
@@ -307,7 +315,10 @@ namespace UsaloYa.Services
                     DateAdded = Utils.GetMxDateTime(),
                     CompanyId = companyId,
                     AlertaStockNumProducts = productDto.LowInventoryStart ?? 0,
-                    IsInVentarioUpdated = productDto.IsInventarioUpdated
+                    IsInVentarioUpdated = productDto.IsInventarioUpdated,
+                    InVentario = 0
+
+
                 };
 
                 _dBContext.Products.Add(existingProduct);


### PR DESCRIPTION
Ahora la edición de cantidades requiere doble clic y Enter; se corrige error al actualizar productos de Kg a Unidad redondeando hacia abajo a entero